### PR TITLE
feature_persistent_friend_request

### DIFF
--- a/app/src/main/java/com/example/ekhogo/friends/FriendsRepository.kt
+++ b/app/src/main/java/com/example/ekhogo/friends/FriendsRepository.kt
@@ -10,9 +10,13 @@ class FriendsRepository {
     private val db = FirebaseFirestore.getInstance()
     private val auth = FirebaseAuth.getInstance()
 
-    fun sendFriendRequest(toUserId: String) {
-        val currentUserId = auth.currentUser?.uid ?: return
+    fun sendFriendRequest(toUserId: String, onComplete: (Boolean) -> Unit = {}) {
+        val currentUserId = auth.currentUser?.uid ?: run {
+            onComplete(false)
+            return
+        }
 
+        val requestId = "${currentUserId}_${toUserId}"
         val request = hashMapOf(
             "fromUserId" to currentUserId,
             "toUserId" to toUserId,
@@ -21,45 +25,182 @@ class FriendsRepository {
         )
 
         db.collection("friend_requests")
-            .add(request)
+            .document(requestId)
+            .set(request)
             .addOnSuccessListener {
                 Log.d("FRIENDS", "Friend request sent")
+                onComplete(true)
             }
             .addOnFailureListener {
                 Log.e("FRIENDS", "Error sending request", it)
+                onComplete(false)
             }
     }
 
-    fun loadUsers(
-        onResult: (List<Friend>) -> Unit
-    ) {
-        val currentUserId = auth.currentUser?.uid ?: return
+    fun loadUsers(onResult: (List<Friend>) -> Unit) {
+        val currentUserId = auth.currentUser?.uid ?: run {
+            onResult(emptyList())
+            return
+        }
 
         db.collection("users")
+            .document(currentUserId)
             .get()
-            .addOnSuccessListener { snapshot ->
-                val users = snapshot.documents.mapNotNull { document ->
-                    val uid = document.getString("uid") ?: document.id
-                    val name = document.getString("name") ?: return@mapNotNull null
-                    val major = document.getString("major") ?: ""
+            .addOnSuccessListener { currentUserDocument ->
+                val currentFriends = (currentUserDocument.get("friends") as? List<*>)
+                    ?.filterIsInstance<String>()
+                    ?.toSet()
+                    ?: emptySet()
 
-                    if (uid == currentUserId) {
-                        null
-                    } else {
-                        Friend(
-                            id = uid,
-                            name = name,
-                            major = major,
-                            status = FriendStatus.NONE
-                        )
+                db.collection("friend_requests")
+                    .whereEqualTo("toUserId", currentUserId)
+                    .whereEqualTo("status", "pending")
+                    .get()
+                    .addOnSuccessListener { incomingSnapshot ->
+                            val incomingRequestUserIds = incomingSnapshot.documents.mapNotNull { document->
+                                document.getString("fromUserId")
+                            }.toSet()
+
+                            db.collection("friend_requests")
+                                .whereEqualTo("fromUserId", currentUserId)
+                                .whereEqualTo("status", "pending")
+                                .get()
+                                .addOnSuccessListener { outgoingSnapshot ->
+                                    val outgoingRequestUserIds = outgoingSnapshot.documents.mapNotNull { document ->
+                                        document.getString("toUserId")
+                                    }.toSet()
+
+                                    db.collection("users")
+                                        .get()
+                                        .addOnSuccessListener { usersSnapshot ->
+                                            val users = usersSnapshot.documents.mapNotNull { document ->
+                                                val uid = document.getString("uid") ?: document.id
+                                                val name = document.getString("name") ?: return@mapNotNull null
+                                                val major = document.getString("major") ?: ""
+
+                                                if (uid == currentUserId) {
+                                                    return@mapNotNull null
+                                                }
+
+                                                val status = when {
+                                                    currentFriends.contains(uid) -> FriendStatus.FRIENDS
+                                                    incomingRequestUserIds.contains(uid) -> FriendStatus.REQUEST_RECEIVED
+                                                    outgoingRequestUserIds.contains(uid) -> FriendStatus.REQUEST_SENT
+                                                    else -> FriendStatus.NONE
+                                                }
+
+                                                Friend(
+                                                    id = uid,
+                                                    name = name,
+                                                    major = major,
+                                                    status = status
+                                                )
+                                            }.sortedBy { it.name.lowercase() }
+
+                                            onResult(users)
+                                        }
+                                        .addOnFailureListener { e ->
+                                            Log.e("FRIENDS", "Error loading users", e)
+                                            onResult(emptyList())
+                                        }
+                                }
+                                .addOnFailureListener { e ->
+                                    Log.e("FRIENDS", "Error loading outgoing requests", e)
+                                    onResult(emptyList())
+                                }
                     }
-                }
-
-                onResult(users)
+                    .addOnFailureListener { e ->
+                        Log.e("FRIENDS", "Error loading incoming requests", e)
+                        onResult(emptyList())
+                    }
             }
             .addOnFailureListener { e ->
-                Log.e("FRIENDS", "Error loading users", e)
+                Log.e("FRIENDS", "Error loading current user", e)
                 onResult(emptyList())
             }
     }
+
+    fun acceptFriendRequest(fromUserId: String, onComplete: (Boolean) -> Unit = {}) {
+        val currentUserId = auth.currentUser?.uid ?: run {
+            onComplete(false)
+            return
+        }
+
+        val requestId =  "$(fromUserId)_${currentUserId}"
+        val requestRef = db.collection("friend_requests").document(requestId)
+        val currentUserRef = db.collection("users").document(currentUserId)
+        val otherUserRef = db.collection("users").document(fromUserId)
+
+        val batch = db.batch()
+        batch.update(
+            requestRef,
+            mapOf<String, Any>(
+                "status" to "accepted",
+                "respondedAt" to FieldValue.serverTimestamp()
+            )
+        )
+        batch.update(currentUserRef, "friends", FieldValue.arrayUnion(fromUserId))
+        batch.update(otherUserRef, "friends", FieldValue.arrayUnion(currentUserId))
+
+        batch.commit()
+            .addOnSuccessListener {
+                Log.d("FRIENDS", "Friend request accepted")
+                onComplete(true)
+            }
+            .addOnFailureListener { e ->
+                Log.e("FRIENDS", "Error accepting friend request", e)
+                onComplete(false)
+            }
+    }
+
+    fun rejectFriendRequest(fromUserId: String, onComplete: (Boolean) -> Unit = {}) {
+        val currentUserId = auth.currentUser?.uid ?: run {
+            onComplete(false)
+            return
+        }
+
+        val requestId = "$(fromUserId)_${currentUserId}"
+
+        db.collection("friend_requests")
+            .document(requestId)
+            .update(
+                mapOf<String, Any>(
+                    "status" to "rejected",
+                    "respondedAt" to FieldValue.serverTimestamp()
+                )
+            )
+            .addOnSuccessListener {
+                Log.d("FRIENDS", "Friend request rejected")
+                onComplete(true)
+            }
+            .addOnFailureListener { e ->
+                Log.d("FRIENDS", "Error rejecting friend request", e)
+                onComplete(false)
+            }
+    }
+
+    fun removeFriend(fromUserId: String, onComplete: (Boolean) -> Unit = {}) {
+        val currentUserId = auth.currentUser?.uid ?: run {
+            onComplete(false)
+            return
+        }
+
+        val currentUserRef = db.collection("users").document(currentUserId)
+        val otherUserRef = db.collection("users").document(fromUserId)
+
+        val batch = db.batch()
+        batch.update(currentUserRef, "friends", FieldValue.arrayRemove(fromUserId))
+        batch.update(otherUserRef, "friends", FieldValue.arrayRemove(currentUserId))
+
+        batch.commit()
+            .addOnSuccessListener {
+                Log.d("FRIENDS", "Friend removed")
+                onComplete(true)
+            }
+            .addOnFailureListener { e ->
+                Log.d("FRIENDS", "Error removing friend", e)
+                onComplete(false)
+            }
+    }
+
 }

--- a/app/src/main/java/com/example/ekhogo/friends/FriendsRepository.kt
+++ b/app/src/main/java/com/example/ekhogo/friends/FriendsRepository.kt
@@ -10,6 +10,25 @@ class FriendsRepository {
     private val db = FirebaseFirestore.getInstance()
     private val auth = FirebaseAuth.getInstance()
 
+    private fun findFriendRequestDocument(
+        fromUserId: String,
+        toUserId: String,
+        onResult: (String?) -> Unit
+    ) {
+        db.collection("friend_requests")
+            .whereEqualTo("fromUserId", fromUserId)
+            .whereEqualTo("toUserId", toUserId)
+            .limit(1)
+            .get()
+            .addOnSuccessListener { snapshot ->
+                onResult(snapshot.documents.firstOrNull()?.id)
+            }
+            .addOnFailureListener { e ->
+                Log.e("FRIENDS", "Error finding friend request", e)
+                onResult(null)
+            }
+    }
+
     fun sendFriendRequest(toUserId: String, onComplete: (Boolean) -> Unit = {}) {
         val currentUserId = auth.currentUser?.uid ?: run {
             onComplete(false)
@@ -126,31 +145,38 @@ class FriendsRepository {
             return
         }
 
-        val requestId =  "$(fromUserId)_${currentUserId}"
-        val requestRef = db.collection("friend_requests").document(requestId)
-        val currentUserRef = db.collection("users").document(currentUserId)
-        val otherUserRef = db.collection("users").document(fromUserId)
-
-        val batch = db.batch()
-        batch.update(
-            requestRef,
-            mapOf<String, Any>(
-                "status" to "accepted",
-                "respondedAt" to FieldValue.serverTimestamp()
-            )
-        )
-        batch.update(currentUserRef, "friends", FieldValue.arrayUnion(fromUserId))
-        batch.update(otherUserRef, "friends", FieldValue.arrayUnion(currentUserId))
-
-        batch.commit()
-            .addOnSuccessListener {
-                Log.d("FRIENDS", "Friend request accepted")
-                onComplete(true)
-            }
-            .addOnFailureListener { e ->
-                Log.e("FRIENDS", "Error accepting friend request", e)
+        findFriendRequestDocument(fromUserId, currentUserId) { requestId ->
+            if (requestId == null) {
+                Log.e("FRIENDS", "No friend request found to accept")
                 onComplete(false)
+                return@findFriendRequestDocument
             }
+
+            val requestRef = db.collection("friend_requests").document(requestId)
+            val currentUserRef = db.collection("users").document(currentUserId)
+            val otherUserRef = db.collection("users").document(fromUserId)
+
+            val batch = db.batch()
+            batch.update(
+                requestRef,
+                mapOf<String, Any>(
+                    "status" to "accepted",
+                    "respondedAt" to FieldValue.serverTimestamp()
+                )
+            )
+            batch.update(currentUserRef, "friends", FieldValue.arrayUnion(fromUserId))
+            batch.update(otherUserRef, "friends", FieldValue.arrayUnion(currentUserId))
+
+            batch.commit()
+                .addOnSuccessListener {
+                    Log.d("FRIENDS", "Friend request accepted")
+                    onComplete(true)
+                }
+                .addOnFailureListener { e ->
+                    Log.e("FRIENDS", "Error accepting friend request", e)
+                    onComplete(false)
+                }
+        }
     }
 
     fun rejectFriendRequest(fromUserId: String, onComplete: (Boolean) -> Unit = {}) {
@@ -159,24 +185,30 @@ class FriendsRepository {
             return
         }
 
-        val requestId = "$(fromUserId)_${currentUserId}"
-
-        db.collection("friend_requests")
-            .document(requestId)
-            .update(
-                mapOf<String, Any>(
-                    "status" to "rejected",
-                    "respondedAt" to FieldValue.serverTimestamp()
-                )
-            )
-            .addOnSuccessListener {
-                Log.d("FRIENDS", "Friend request rejected")
-                onComplete(true)
-            }
-            .addOnFailureListener { e ->
-                Log.d("FRIENDS", "Error rejecting friend request", e)
+        findFriendRequestDocument(fromUserId, currentUserId) { requestId ->
+            if (requestId == null) {
+                Log.e("FRIENDS", "No friend request found to reject")
                 onComplete(false)
+                return@findFriendRequestDocument
             }
+
+            db.collection("friend_requests")
+                .document(requestId)
+                .update(
+                    mapOf<String, Any>(
+                        "status" to "rejected",
+                        "respondedAt" to FieldValue.serverTimestamp()
+                    )
+                )
+                .addOnSuccessListener {
+                    Log.d("FRIENDS", "Friend request rejected")
+                    onComplete(true)
+                }
+                .addOnFailureListener { e ->
+                    Log.d("FRIENDS", "Error rejecting friend request", e)
+                    onComplete(false)
+                }
+        }
     }
 
     fun removeFriend(fromUserId: String, onComplete: (Boolean) -> Unit = {}) {

--- a/app/src/main/java/com/example/ekhogo/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/example/ekhogo/friends/FriendsScreen.kt
@@ -38,29 +38,24 @@ fun FriendsScreen(
     viewModel: MessagesViewModel,
     onNavigateToMessages: () -> Unit
 ) {
-    // Temporary mock data for demo purposes until login / Firebase friend data is added later
-    var classmates by remember {
-        mutableStateOf(
-            listOf(
-                Friend("1", "Tahja Martin", "Computer Science", FriendStatus.FRIENDS),
-                Friend("2", "Kristopher Arakelyan", "Computer Science", FriendStatus.FRIENDS),
-                Friend("3", "Chris Hernandez", "Computer Science", FriendStatus.REQUEST_RECEIVED),
-                Friend("4", "Jude Segundera", "Computer Science", FriendStatus.NONE)
-            )
-        )
-    }
+
+    var classmates by remember { mutableStateOf<List<Friend>>(emptyList()) }
     // selectedTab controls which friend category is displayed
     var selectedTab by remember { mutableStateOf(FriendsTab.FRIENDS) }
     // searchText is used when clicking on the add friend tab to search for a user
     var searchText by remember { mutableStateOf("") }
 
     // Connecting to the database
-    val repository = FriendsRepository()
+    val repository = remember { FriendsRepository() }
 
-    LaunchedEffect(Unit) {
+    fun refreshClassmates() {
         repository.loadUsers { users ->
             classmates = users
         }
+    }
+
+    LaunchedEffect(Unit) {
+        refreshClassmates()
     }
 
     // filter the full classmate list based on the selected tab
@@ -206,39 +201,36 @@ fun FriendsScreen(
                             Column {
                                 Button(
                                     onClick = {
-                                        classmates = classmates.map { currentFriend ->
-
-                                            if (currentFriend.id == friend.id) {
-
-                                                when (currentFriend.status) {
-
-                                                    FriendStatus.NONE -> {
-                                                        repository.sendFriendRequest(currentFriend.id)
-                                                        currentFriend.copy(status = FriendStatus.REQUEST_SENT)
-                                                    }
-
-                                                    FriendStatus.REQUEST_RECEIVED -> {
-                                                        currentFriend.copy(status = FriendStatus.FRIENDS)
-                                                    }
-
-                                                    FriendStatus.REQUEST_SENT -> {
-                                                        currentFriend
-                                                    }
-
-                                                    FriendStatus.FRIENDS -> {
-                                                        currentFriend.copy(status = FriendStatus.NONE)
+                                            when (friend.status) {
+                                                FriendStatus.NONE -> {
+                                                    repository.sendFriendRequest(friend.id) { success ->
+                                                        if (success) {
+                                                            refreshClassmates()
+                                                        }
                                                     }
                                                 }
 
-                                            } else {
-                                                currentFriend
+                                                FriendStatus.REQUEST_RECEIVED -> {
+                                                    repository.acceptFriendRequest(friend.id) { success ->
+                                                        if (success) {
+                                                            refreshClassmates()
+                                                        }
+                                                    }
+                                                }
+
+                                                FriendStatus.REQUEST_SENT -> Unit
+
+                                                FriendStatus.FRIENDS -> {
+                                                    repository.removeFriend(friend.id)  { success ->
+                                                        if (success) {
+                                                            refreshClassmates()
+                                                        }
+                                                    }
+                                                }
                                             }
-                                        }
                                     },
                                     // Button is only interactable when an action can happen
-                                    enabled = friend.status == FriendStatus.NONE ||
-                                            friend.status == FriendStatus.REQUEST_RECEIVED ||
-                                            friend.status == FriendStatus.FRIENDS
+                                    enabled = friend.status != FriendStatus.REQUEST_SENT
                                 ) {
                                     Text(
                                         // Update button text based on the current relationship status
@@ -246,20 +238,34 @@ fun FriendsScreen(
                                             FriendStatus.NONE -> "Add"
                                             FriendStatus.REQUEST_SENT -> "Pending"
                                             FriendStatus.REQUEST_RECEIVED -> "Accept"
-                                            FriendStatus.FRIENDS ->
-                                                if (selectedTab == FriendsTab.FRIENDS) "Unfriend" else "Friends"
+                                            FriendStatus.FRIENDS -> "Unfriend"
                                         }
                                     )
                                 }
+
                                 Spacer(modifier = Modifier.height(8.dp))
 
-                                Button(
-                                    onClick = {
-                                        viewModel.openConversation(friend.id)
-                                        onNavigateToMessages()
+                                if (friend.status == FriendStatus.REQUEST_RECEIVED) {
+                                    OutlinedButton(
+                                        onClick = {
+                                            repository.rejectFriendRequest(friend.id) { success ->
+                                                if (success) {
+                                                    refreshClassmates()
+                                                }
+                                            }
+                                        }
+                                    ) {
+                                        Text("Decline")
                                     }
-                                ) {
-                                    Text("Message")
+                                } else if (friend.status == FriendStatus.FRIENDS) {
+                                    Button(
+                                        onClick = {
+                                            viewModel.openConversation(friend.id)
+                                            onNavigateToMessages()
+                                        }
+                                    ) {
+                                        Text("Message")
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
+++ b/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
@@ -45,7 +45,7 @@ fun MessagesScreen(viewModel: MessagesViewModel) {
     // Listen for messages from Firestore in real time
     DisposableEffect(Unit) {
         viewModel.onMessagesScreenOpened()
-        viewModel.loadMockConversationPreviews()
+        viewModel.loadConversationsPreview()
 
         onDispose {
             viewModel.onMessagesScreenClosed()

--- a/app/src/main/java/com/example/ekhogo/message/MessagesViewModel.kt
+++ b/app/src/main/java/com/example/ekhogo/message/MessagesViewModel.kt
@@ -7,6 +7,7 @@ import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,41 +44,59 @@ class MessagesViewModel : ViewModel() {
     private val _unreadCount = MutableStateFlow(0)
     val unreadCount: StateFlow<Int> = _unreadCount.asStateFlow()
 
+    private val _messageError = MutableStateFlow<String?>(null)
+
     private var currentUserId: String = ""
 
     private var activeConversationId: String? = null
-    private var listenerRegistration: ListenerRegistration? = null
+
+    private var activeOtherUserId: String? = null
+    private var messagesListenerRegistration: ListenerRegistration? = null
+    private var conversationsListenerRegistration: ListenerRegistration? = null
     private var isMessagesScreenOpen = false
     private var latestSeenTimestamp = 0L
     private var latestMessageTimestamp = 0L
     private var hasLoadedInitialSnapshot = false
 
     init {
-        ensureSignedInAndListen()
+        refreshCurrentUserId()
     }
 
-    private fun ensureSignedInAndListen() {
-        if (auth.currentUser == null) {
-            auth.signInAnonymously()
-                .addOnSuccessListener {
-                    currentUserId = auth.currentUser?.uid ?: ""
-                    Log.d("AUTH", "Annonymous sign-in success: $currentUserId")
-                }
-                .addOnFailureListener { e ->
-                    Log.e("AUTH", "Anonnymous sign-in failed", e)
-                }
-        } else {
-            currentUserId = auth.currentUser?.uid ?: ""
-            Log.d("AUTH", "Already signed in : $currentUserId")
+    private fun refreshCurrentUserId(): Boolean {
+        currentUserId = auth.currentUser?.uid ?: ""
+        if (currentUserId.isBlank()) {
+            Log.w("AUTH", "No signed-in user available for messaging")
         }
+        return currentUserId.isNotBlank()
     }
 
+    private fun isFriendWith(otherUserId: String, onResult: (Boolean) -> Unit) {
+        if (!refreshCurrentUserId()) {
+            onResult(false)
+            return
+        }
+
+        db.collection("users")
+            .document(currentUserId)
+            .get()
+            .addOnSuccessListener { document ->
+                val friends = (document.get("friends") as? List<*>)
+                    ?.filterIsInstance<String>()
+                    ?: emptyList()
+
+                onResult(friends.contains(otherUserId))
+            }
+            .addOnFailureListener { e ->
+                Log.e("FIREBASE", "Error checking friendship", e)
+                onResult(false)
+            }
+    }
     private fun startMessagesListener() {
         val conversationId = activeConversationId ?: return
         if (currentUserId.isBlank()) return
 
-        listenerRegistration?.remove()
-        listenerRegistration = db.collection("conversations")
+        messagesListenerRegistration?.remove()
+        messagesListenerRegistration = db.collection("conversations")
             .document(conversationId)
             .collection("messages")
             .orderBy("timestamp", Query.Direction.ASCENDING)
@@ -136,36 +155,163 @@ class MessagesViewModel : ViewModel() {
     fun openConversation(otherUserId: String) {
         if (currentUserId.isBlank()) return
 
-        activeConversationId = getConversationId(currentUserId, otherUserId)
-        _isInConversation.value = true
-        startMessagesListener()
+        isFriendWith(otherUserId) { isFriend ->
+            if (!isFriend) {
+                _messageError.value = "You can only message accepted friends."
+                return@isFriendWith
+            }
+
+            activeOtherUserId = otherUserId
+            activeConversationId = getConversationId(currentUserId, otherUserId)
+            _isInConversation.value = true
+            _messageError.value = null
+            _messages.value = emptyList()
+            latestSeenTimestamp = 0L
+            latestMessageTimestamp = 0L
+            hasLoadedInitialSnapshot = false
+            startMessagesListener()
+        }
     }
 
     fun closeConversation() {
         activeConversationId = null
+        activeOtherUserId = null
         _isInConversation.value = false
         _messages.value = emptyList()
+        _messageError.value = null
     }
 
-    fun sendMessage(text: String) {
-        val conversationId = activeConversationId ?: return
-        if (text.isBlank() || currentUserId.isBlank()) return
+    fun sendMessage(text: String, onComplete: (Boolean) -> Unit = {}) {
+        val conversationId = activeConversationId ?: run {
+            onComplete(false)
+            return
+        }
+        val otherUserId = activeOtherUserId ?: run {
+            onComplete(false)
+            return
+        }
 
-        val messageData = hashMapOf(
-            "text" to text,
-            "senderId" to currentUserId,
-            "timestamp" to FieldValue.serverTimestamp()
-        )
+        if (text.isBlank() || !refreshCurrentUserId()) {
+            onComplete(false)
+            return
+        }
 
-        db.collection("conversations")
-            .document(conversationId)
-            .collection("messages")
-            .add(messageData)
-            .addOnSuccessListener {
-                Log.d("FIREBASE", "Message sent successfully!")
+        isFriendWith(otherUserId) { isFriend ->
+            if (!isFriend) {
+                _messageError.value = "You can only message accepted friends."
+                onComplete(false)
+                return@isFriendWith
             }
-            .addOnFailureListener { e ->
-                Log.e("FIREBASE", "error sending message", e)
+
+            val conversationRef = db.collection("conversations").document(conversationId)
+            val messageRef = conversationRef.collection("messages").document()
+
+            val messageData = hashMapOf(
+                "text" to text,
+                "senderId" to currentUserId,
+                "timestamp" to FieldValue.serverTimestamp()
+            )
+
+            val conversationData = hashMapOf(
+                "participants" to listOf(currentUserId, otherUserId).sorted(),
+                "lastMessage" to text,
+                "lastMessageTimestamp" to FieldValue.serverTimestamp()
+            )
+
+            val batch = db.batch()
+            batch.set(conversationRef, conversationData, SetOptions.merge())
+            batch.set(messageRef, messageData)
+
+            batch.commit()
+                .addOnSuccessListener {
+                    _messageError.value = null
+                    Log.d("FIREBASE", "Message sent successfully!")
+                    onComplete(true)
+                }
+                .addOnFailureListener { e ->
+                    Log.e("FIREBASE", "Error sending message", e)
+                    _messageError.value = "Could not send message."
+                    onComplete(false)
+                }
+        }
+    }
+
+    fun loadConversationsPreview() {
+        if (!refreshCurrentUserId()) return
+
+        conversationsListenerRegistration?.remove()
+        conversationsListenerRegistration = db.collection("conversations")
+            .whereArrayContains("participants", currentUserId)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    Log.e("FIREBASE", "Error loading conversation previews", error)
+                    return@addSnapshotListener
+                }
+
+                val documents = snapshot?.documents.orEmpty()
+                    .sortedByDescending { document ->
+                        document.getTimestamp("lastMessageTimestamp")?.toDate()?.time ?: 0L
+                    }
+
+                if (documents.isEmpty()) {
+                    _conversationPreviews.value = emptyList()
+                    return@addSnapshotListener
+                }
+
+                val previewSlots = MutableList<ConversationPreview?>(documents.size) { null }
+                var remaining = documents.size
+
+                fun publishIfReady() {
+                    if (remaining == 0) {
+                        _conversationPreviews.value = previewSlots.filterNotNull()
+                    }
+                }
+
+                documents.forEachIndexed { index, document ->
+                    val participants = (document.get("participants") as? List<*>)
+                        ?.filterIsInstance<String>()
+                        ?: emptyList()
+
+                    val otherUserId = participants.firstOrNull { it != currentUserId }
+                    val lastMessage = document.getString("lastMessage") ?: ""
+
+                    if (otherUserId == null) {
+                        remaining -= 1
+                        publishIfReady()
+                        return@forEachIndexed
+                    }
+
+                    db.collection("users")
+                        .document(otherUserId)
+                        .get()
+                        .addOnSuccessListener { userDocument ->
+                            val otherUserName = userDocument.getString("name")
+                                ?.takeIf { it.isNotBlank() }
+                                ?: userDocument.getString("email")
+                                ?: "Unknown User"
+
+                            previewSlots[index] = ConversationPreview(
+                                otherUserId = otherUserId,
+                                otherUserName = otherUserName,
+                                lastMessage = lastMessage
+                            )
+
+                            remaining -= 1
+                            publishIfReady()
+                        }
+                        .addOnFailureListener { e ->
+                            Log.e("FIREBASE", "Error loading conversation user", e)
+
+                            previewSlots[index] = ConversationPreview(
+                                otherUserId = otherUserId,
+                                otherUserName = "Unknown User",
+                                lastMessage = lastMessage
+                            )
+
+                            remaining -= 1
+                            publishIfReady()
+                        }
+                }
             }
     }
 
@@ -180,27 +326,8 @@ class MessagesViewModel : ViewModel() {
     }
 
     override fun onCleared() {
-        listenerRegistration?.remove()
+        messagesListenerRegistration?.remove()
+        conversationsListenerRegistration?.remove()
         super.onCleared()
-    }
-
-    fun loadMockConversationPreviews() {
-        _conversationPreviews.value = listOf(
-            ConversationPreview(
-                otherUserId = "1",
-                otherUserName = "Tahja Martin",
-                lastMessage = "Hey, are you going to class?"
-            ),
-            ConversationPreview(
-                otherUserId = "2",
-                otherUserName = "Kristopher Arakelyan",
-                lastMessage = "I sent the update last night."
-            ),
-            ConversationPreview(
-                otherUserId = "3",
-                otherUserName = "Chris Hernandez",
-                lastMessage = "Did you do the PR?"
-            )
-        )
     }
 }


### PR DESCRIPTION

Summary: This PR replaces the local friend data and latest message preview with Firestore data. Messaging is also now only allowed between friends. 

Changes
- Persist friend requests to the 'friend_requests' collection instead of relying on local UI
- Uses 'users/{uid}.friends' array as the source of truth for accepted friendships        
- Load real friend state into Friends screen by combining the current user's 'friends' array, incoming pending requests, outgoing pending requests
- Support these friend actions from the UI: send request, accept request, decline request, unfriend
- Refresh the Friends screen from Firestore after each successful action
- Added request lookup by 'fromUserId' + 'toUserId' when accepting/rejecting so reciever-side actions work even if older request docs were created with non-deterministic IDs
- Restrict conversations to accepted friends only
- Add friendship checks before opening a conversation and before sending a message
- Replace mock conversation preview with Firestore data previews.
- Write/update conversation metadata when sending a message: 'participants', 'lastMessage', 'lastMessageTimestamp'
- fix messaging typos/issues that were preventing conversation preview loading and correct conversation writes. 

Improvements
- Unread message badge count still needs improvement: currently depends on when conversation preview/loading starts
- Push notifications are not yet implemented
- Friends repository uses nested Firestore reads and could be refactored for better readability

Notes
Accepted friendships are stored on `users/{uid}.friends`.
- Pending requests are stored in `friend_requests`.
- New requests are written with deterministic IDs (`fromUserId_toUserId`), but accept/reject now queries by `fromUserId` and `toUserId` to remain compatible with older docs.