### PR TITLE
Feature delete thread

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation.layout)
     implementation(libs.places)
     implementation(libs.firebase.appcheck.debug)
+    implementation(libs.androidx.foundation)
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/com/example/ekhogo/HomeScreen.kt
+++ b/app/src/main/java/com/example/ekhogo/HomeScreen.kt
@@ -268,7 +268,7 @@ fun HomeScreen(
                 3 -> CampusMapScreen()
 
                 // If Messages is selected
-                4 -> MessagesScreen(viewModel = messagesViewModel)
+                4 -> MessagesScreen(viewModel = messagesViewModel,)
 
                 // If Schedule button on homescreen is selected
                 5 -> Schedule()

--- a/app/src/main/java/com/example/ekhogo/friends/FriendsLogic.kt
+++ b/app/src/main/java/com/example/ekhogo/friends/FriendsLogic.kt
@@ -1,2 +1,0 @@
-package com.example.ekhogo.friends
-

--- a/app/src/main/java/com/example/ekhogo/message/ChatMessage.kt
+++ b/app/src/main/java/com/example/ekhogo/message/ChatMessage.kt
@@ -2,5 +2,6 @@ package com.example.ekhogo.message
 
 data class ChatMessage(
     val text: String,
-    val isSentByMe: Boolean
+    val isSentByMe: Boolean,
+    val id: String
 )

--- a/app/src/main/java/com/example/ekhogo/message/ChatMessage.kt
+++ b/app/src/main/java/com/example/ekhogo/message/ChatMessage.kt
@@ -1,4 +1,6 @@
 package com.example.ekhogo.message
 
-class ChatMessage {
-}
+data class ChatMessage(
+    val text: String,
+    val isSentByMe: Boolean
+)

--- a/app/src/main/java/com/example/ekhogo/message/ChatMessage.kt
+++ b/app/src/main/java/com/example/ekhogo/message/ChatMessage.kt
@@ -1,0 +1,4 @@
+package com.example.ekhogo.message
+
+class ChatMessage {
+}

--- a/app/src/main/java/com/example/ekhogo/message/ConversationPreview.kt
+++ b/app/src/main/java/com/example/ekhogo/message/ConversationPreview.kt
@@ -1,0 +1,4 @@
+package com.example.ekhogo.message
+
+class ConversationPreview {
+}

--- a/app/src/main/java/com/example/ekhogo/message/ConversationPreview.kt
+++ b/app/src/main/java/com/example/ekhogo/message/ConversationPreview.kt
@@ -1,4 +1,8 @@
 package com.example.ekhogo.message
 
-class ConversationPreview {
-}
+data class ConversationPreview(
+    val otherUserId: String,
+    val otherUserName: String,
+    val lastMessage: String,
+    val numOfParticipants: Int
+)

--- a/app/src/main/java/com/example/ekhogo/message/ConversationPreview.kt
+++ b/app/src/main/java/com/example/ekhogo/message/ConversationPreview.kt
@@ -1,8 +1,11 @@
 package com.example.ekhogo.message
 
+import kotlin.collections.emptyList
+
 data class ConversationPreview(
     val otherUserId: String,
     val otherUserName: String,
     val lastMessage: String,
-    val numOfParticipants: Int
+    val numOfParticipants: Int,
+    val deletedFor: List<String>
 )

--- a/app/src/main/java/com/example/ekhogo/message/DeleteMessageThread.kt
+++ b/app/src/main/java/com/example/ekhogo/message/DeleteMessageThread.kt
@@ -1,2 +1,30 @@
 package com.example.ekhogo.message
 
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+
+
+fun deleteMessageThread(otherUserId: String){
+
+        val db = FirebaseFirestore.getInstance()
+        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+
+
+        val conversationId = listOf(uid, otherUserId)
+            .sorted()
+            .joinToString("_")
+
+        db.collection("conversations")
+            .document(conversationId)
+            .update(
+                "deletedFor", FieldValue.arrayUnion(uid)
+            )
+
+
+
+
+
+
+
+}

--- a/app/src/main/java/com/example/ekhogo/message/DeleteMessageThread.kt
+++ b/app/src/main/java/com/example/ekhogo/message/DeleteMessageThread.kt
@@ -1,0 +1,2 @@
+package com.example.ekhogo.message
+

--- a/app/src/main/java/com/example/ekhogo/message/DeleteMessageThread.kt
+++ b/app/src/main/java/com/example/ekhogo/message/DeleteMessageThread.kt
@@ -15,16 +15,35 @@ fun deleteMessageThread(otherUserId: String){
             .sorted()
             .joinToString("_")
 
-        db.collection("conversations")
-            .document(conversationId)
-            .update(
-                "deletedFor", FieldValue.arrayUnion(uid)
-            )
+    val doc= db.collection("conversations")
+        .document(conversationId)
+
+    doc.update("deletedFor", FieldValue.arrayUnion(uid))
+        .addOnSuccessListener {
+            doc.get().addOnSuccessListener { document ->
+                val deletedFor = document.get("deletedFor") as? List<String> ?: emptyList()
+                val participants = document.getLong("numOfParticipants")
+
+                if (deletedFor.size.toLong() == participants) {
+
+                    val messagesRef = doc.collection("messages")
+
+                    messagesRef.get().addOnSuccessListener { snapshot ->
+                        val batch = db.batch()
+
+                        for (message in snapshot.documents) {
+                            batch.delete(message.reference)
+                        }
+
+                        batch.commit().addOnSuccessListener {
+                            doc.delete()
+                        }
+                    }
 
 
-
-
-
-
+                   doc.delete()
+                }
+            }
+        }
 
 }

--- a/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
+++ b/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
@@ -10,21 +10,32 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.ui.draw.clip
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Icon
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 // This is the screen that shows when Messages tab is selected
@@ -78,28 +89,69 @@ fun MessagesScreen(viewModel: MessagesViewModel) {
                 ) {
                     items(conversationPreviews) { preview ->
 
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    viewModel.openConversation(preview.otherUserId)
+                        val swipeToDismissBoxState = rememberSwipeToDismissBoxState(
+                            confirmValueChange = {
+                                if (it == SwipeToDismissBoxValue.EndToStart){
+                                    deleteMessageThread(preview.otherUserId)
                                 }
-                                .padding(12.dp)
-                                .background(MaterialTheme.colorScheme.surfaceVariant)
-                                .padding(12.dp)
-                        ) {
-                            Text(
-                                text = preview.otherUserName,
-                                style = MaterialTheme.typography.titleMedium
-                            )
+                                it != SwipeToDismissBoxValue.StartToEnd
+                            }
+                        )
 
-                            Spacer(modifier = Modifier.height(4.dp))
 
-                            Text(
-                                text = preview.lastMessage,
-                                style = MaterialTheme.typography.bodySmall
-                            )
-                        }
+
+
+                        SwipeToDismissBox(
+                            state = swipeToDismissBoxState,
+                            enableDismissFromStartToEnd = false,
+                            enableDismissFromEndToStart = true,
+
+                            backgroundContent = {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = 12.dp, vertical = 6.dp),
+                                    contentAlignment = Alignment.CenterEnd
+                                )  {
+                                    Icon(
+                                        imageVector = Icons.Default.Delete,
+                                        contentDescription = "Delete Icon",
+                                        tint = Color.Red
+                                    )
+                                }
+                            },
+
+                            content = {
+                                Card(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                                        .clickable {
+                                            viewModel.openConversation(preview.otherUserId)
+                                        },
+                                    shape = RoundedCornerShape(12.dp),
+                                    elevation = CardDefaults.cardElevation(4.dp)
+                                ) {
+                                    Column(
+                                        modifier = Modifier
+                                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                                            .padding(12.dp)
+                                    ) {
+                                        Text(
+                                            text = preview.otherUserName,
+                                            style = MaterialTheme.typography.titleMedium
+                                        )
+
+                                        Spacer(modifier = Modifier.height(4.dp))
+
+                                        Text(
+                                            text = preview.lastMessage,
+                                            style = MaterialTheme.typography.bodySmall
+                                        )
+                                    }
+                                }
+                            }
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
+++ b/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
@@ -3,20 +3,24 @@ package com.example.ekhogo.message
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.ui.draw.clip
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -25,6 +29,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -37,6 +42,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 
 // This is the screen that shows when Messages tab is selected
 @Composable
@@ -45,11 +52,22 @@ fun MessagesScreen(viewModel: MessagesViewModel) {
     // This stores what the user types in the input box
     val messageText = remember { mutableStateOf("") }
 
+    val db = FirebaseFirestore.getInstance()
+
+    val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+
+    val showUnsend = remember { mutableStateOf(false)}
+
+
+
     // The stores all the messages that have been sent
     val messages by viewModel.messages.collectAsState()
 
     // List of conversation previews (inbox-style chat list)
     val conversationPreviews by viewModel.conversationPreviews.collectAsState()
+
+    val selectMessage = remember { mutableStateOf<ChatMessage?>(null) }
+
 
     val isInConversation by viewModel.isInConversation.collectAsState()
 
@@ -87,111 +105,174 @@ fun MessagesScreen(viewModel: MessagesViewModel) {
                         .weight(1f)
                         .fillMaxWidth()
                 ) {
-                    items(conversationPreviews) { preview ->
+                    items(conversationPreviews.filter { preview ->
+                        !preview.deletedFor.contains(uid)
+                    }){ preview ->
 
-                        val swipeToDismissBoxState = rememberSwipeToDismissBoxState(
-                            confirmValueChange = {
-                                if (it == SwipeToDismissBoxValue.EndToStart){
-                                    deleteMessageThread(preview.otherUserId)
+                            val swipeToDismissBoxState = rememberSwipeToDismissBoxState(
+                                confirmValueChange = {
+                                    if (it == SwipeToDismissBoxValue.EndToStart) {
+                                        deleteMessageThread(preview.otherUserId)
+                                    }
+                                    it != SwipeToDismissBoxValue.StartToEnd
                                 }
-                                it != SwipeToDismissBoxValue.StartToEnd
-                            }
-                        )
+                            )
 
 
+                            SwipeToDismissBox(
+                                state = swipeToDismissBoxState,
+                                enableDismissFromStartToEnd = false,
+                                enableDismissFromEndToStart = true,
 
-
-                        SwipeToDismissBox(
-                            state = swipeToDismissBoxState,
-                            enableDismissFromStartToEnd = false,
-                            enableDismissFromEndToStart = true,
-
-                            backgroundContent = {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .padding(horizontal = 12.dp, vertical = 6.dp),
-                                    contentAlignment = Alignment.CenterEnd
-                                )  {
-                                    Icon(
-                                        imageVector = Icons.Default.Delete,
-                                        contentDescription = "Delete Icon",
-                                        tint = Color.Red
-                                    )
-                                }
-                            },
-
-                            content = {
-                                Card(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .padding(horizontal = 12.dp, vertical = 6.dp)
-                                        .clickable {
-                                            viewModel.openConversation(preview.otherUserId)
-                                        },
-                                    shape = RoundedCornerShape(12.dp),
-                                    elevation = CardDefaults.cardElevation(4.dp)
-                                ) {
-                                    Column(
+                                backgroundContent = {
+                                    Box(
                                         modifier = Modifier
-                                            .background(MaterialTheme.colorScheme.surfaceVariant)
-                                            .padding(12.dp)
+                                            .fillMaxSize()
+                                            .padding(horizontal = 12.dp, vertical = 6.dp),
+                                        contentAlignment = Alignment.CenterEnd
                                     ) {
-                                        Text(
-                                            text = preview.otherUserName,
-                                            style = MaterialTheme.typography.titleMedium
-                                        )
-
-                                        Spacer(modifier = Modifier.height(4.dp))
-
-                                        Text(
-                                            text = preview.lastMessage,
-                                            style = MaterialTheme.typography.bodySmall
+                                        Icon(
+                                            imageVector = Icons.Default.Delete,
+                                            contentDescription = "Delete Icon",
+                                            tint = Color.Red
                                         )
                                     }
+                                },
+
+                                content = {
+                                    Card(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .padding(horizontal = 12.dp, vertical = 6.dp)
+                                            .clickable {
+                                                viewModel.selectOtherUser(preview.otherUserName)
+                                                viewModel.openConversation(preview.otherUserId)
+                                            },
+                                        shape = RoundedCornerShape(12.dp),
+                                        elevation = CardDefaults.cardElevation(4.dp)
+                                    ) {
+                                        Column(
+                                            modifier = Modifier
+                                                .background(MaterialTheme.colorScheme.surfaceVariant)
+                                                .padding(12.dp)
+                                        ) {
+                                            Text(
+                                                text = preview.otherUserName,
+                                                style = MaterialTheme.typography.titleMedium
+                                            )
+
+                                            Spacer(modifier = Modifier.height(4.dp))
+
+                                            Text(
+                                                text = preview.lastMessage,
+                                                style = MaterialTheme.typography.bodySmall
+                                            )
+                                        }
+                                    }
                                 }
-                            }
-                        )
+                            )
+                        }
                     }
-                }
 
             } else {
 
                 // CHAT VIEW
+
+                val listState = rememberLazyListState()
+
+                LaunchedEffect(messages.size) {
+                    if (messages.isNotEmpty()) {
+                        listState.animateScrollToItem(messages.lastIndex)
+                    }
+                }
+
                 LazyColumn(
+                    state = listState,
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
                 ) {
-                    items(messages) { message ->
+                    itemsIndexed(messages) { index, message ->
 
-                        Box(
+                        val prev = messages.getOrNull(index - 1)
+
+                        Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(vertical = 4.dp),
-                            contentAlignment = if (message.isSentByMe) {
-                                Alignment.CenterEnd
-                            } else {
-                                Alignment.CenterStart
-                            }
+                                .padding(vertical = 4.dp)
                         ) {
+
+                            if((prev?.isSentByMe == true || prev == null)&&(message.isSentByMe == false)){
+
+                                val user by viewModel.selectedOtherUser.collectAsState()
+                                Spacer(modifier = Modifier.height(2.dp))
+                                Text(
+                                    text = user,
+                                    fontSize = 14.sp,
+                                )
+
+
+                            }
+
+
                             Text(
                                 text = message.text,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                                color = Color.Black,
                                 modifier = Modifier
+                                    .align(
+                                        if (message.isSentByMe)
+                                            Alignment.End
+                                        else
+                                            Alignment.Start
+                                    )
                                     .background(
-                                        color = if (message.isSentByMe) {
-                                            MaterialTheme.colorScheme.primaryContainer
-                                        } else {
-                                            MaterialTheme.colorScheme.secondaryContainer
-                                        },
+                                        color = if (message.isSentByMe)
+                                            MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)
+                                        else
+                                            MaterialTheme.colorScheme.secondaryContainer,
                                         shape = RoundedCornerShape(12.dp)
                                     )
-                                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                                    .padding(12.dp)
+                                    .combinedClickable(
+                                        enabled = (message.isSentByMe) && (!message.text.endsWith("unsent a message")),
+                                        onClick = {},
+                                        onLongClick = {
+                                            selectMessage.value = message
+                                            showUnsend.value = true
+                                        }
+                                    )
                             )
+                        }
+
                         }
                     }
                 }
+
+
+            if (showUnsend.value) {
+                AlertDialog(
+                    onDismissRequest = { showUnsend.value = false },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            showUnsend.value = false
+                            selectMessage.value?.let { message ->
+                                viewModel.unsendMessage(message.id)
+                            }
+                        }) {
+                            Text("Unsend")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showUnsend.value = false }) {
+                            Text("Cancel")
+                        }
+                    },
+                    title = { Text("Unsend Message") },
+                    text = { Text("Are you sure you want to unsend message?") }
+                )
+            }
+
+
             }
             // BOTTOM:
             // Input field where user types message
@@ -239,4 +320,3 @@ fun MessagesScreen(viewModel: MessagesViewModel) {
             }
         }
     }
-}

--- a/app/src/main/java/com/example/ekhogo/message/MessagesViewModel.kt
+++ b/app/src/main/java/com/example/ekhogo/message/MessagesViewModel.kt
@@ -49,6 +49,11 @@ class MessagesViewModel : ViewModel() {
     private var latestMessageTimestamp = 0L
     private var hasLoadedInitialSnapshot = false
 
+    private val _selectedOtherUser = MutableStateFlow("")
+
+    val selectedOtherUser = _selectedOtherUser.asStateFlow()
+
+
     init {
         refreshCurrentUserId()
     }
@@ -101,10 +106,11 @@ class MessagesViewModel : ViewModel() {
                 _messages.value = documents.map { document ->
                     val text = document.getString("text") ?: ""
                     val senderId = document.getString("senderId") ?: ""
-
+                    val id = document.id
                     ChatMessage(
                         text = text,
-                        isSentByMe = senderId == currentUserId
+                        isSentByMe = senderId == currentUserId,
+                        id = id
                     )
                 }
 
@@ -141,6 +147,10 @@ class MessagesViewModel : ViewModel() {
         return listOf(currentUserId, otherUserId)
             .sorted()
             .joinToString("_")
+    }
+
+    fun selectOtherUser(name: String) {
+        _selectedOtherUser.value = name
     }
 
     fun openConversation(otherUserId: String) {
@@ -268,6 +278,7 @@ class MessagesViewModel : ViewModel() {
                     val otherUserId = participants.firstOrNull { it != currentUserId }
                     val lastMessage = document.getString("lastMessage") ?: ""
                     val numOfParticipants = document.getLong("numOfParticipants")?.toInt() ?: 0
+                    val deletedFor = document.get("deletedFor") as? List<String> ?: emptyList()
 
 
                     if (otherUserId == null) {
@@ -289,7 +300,8 @@ class MessagesViewModel : ViewModel() {
                                 otherUserId = otherUserId,
                                 otherUserName = otherUserName,
                                 lastMessage = lastMessage,
-                                numOfParticipants = numOfParticipants
+                                numOfParticipants = numOfParticipants,
+                                deletedFor = deletedFor
                             )
 
                             remaining -= 1
@@ -302,7 +314,8 @@ class MessagesViewModel : ViewModel() {
                                 otherUserId = otherUserId,
                                 otherUserName = "Unknown User",
                                 lastMessage = lastMessage,
-                                numOfParticipants = numOfParticipants
+                                numOfParticipants = numOfParticipants,
+                                deletedFor = deletedFor
                             )
 
                             remaining -= 1
@@ -320,6 +333,32 @@ class MessagesViewModel : ViewModel() {
 
     fun onMessagesScreenClosed() {
         isMessagesScreenOpen = false
+    }
+
+    fun unsendMessage(message: String){
+
+        val convoID = activeConversationId?: return
+        val message: String = message
+
+        FirebaseFirestore.getInstance()
+            .collection("conversations")
+            .document(convoID)
+            .collection("messages")
+            .document(message)
+            .delete()
+
+        val uid = FirebaseAuth.getInstance().currentUser?.uid ?: return
+
+        FirebaseFirestore.getInstance()
+            .collection("users")
+            .document(uid)
+            .get()
+            .addOnSuccessListener { document ->
+                val name = document.getString("name")
+
+                sendMessage("${name} unsent a message")
+            }
+
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/example/ekhogo/message/MessagesViewModel.kt
+++ b/app/src/main/java/com/example/ekhogo/message/MessagesViewModel.kt
@@ -13,16 +13,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 // Represents one chat message
-data class ChatMessage(
-    val text: String,
-    val isSentByMe: Boolean
-)
 
-data class ConversationPreview(
-    val otherUserId: String,
-    val otherUserName: String,
-    val lastMessage: String
-)
 
 class MessagesViewModel : ViewModel() {
 
@@ -215,7 +206,9 @@ class MessagesViewModel : ViewModel() {
             val conversationData = hashMapOf(
                 "participants" to listOf(currentUserId, otherUserId).sorted(),
                 "lastMessage" to text,
-                "lastMessageTimestamp" to FieldValue.serverTimestamp()
+                "lastMessageTimestamp" to FieldValue.serverTimestamp(),
+                "numOfParticipants" to listOf(currentUserId, otherUserId).sorted().size,
+                "deletedFor" to emptyList<String>()
             )
 
             val batch = db.batch()
@@ -274,6 +267,8 @@ class MessagesViewModel : ViewModel() {
 
                     val otherUserId = participants.firstOrNull { it != currentUserId }
                     val lastMessage = document.getString("lastMessage") ?: ""
+                    val numOfParticipants = document.getLong("numOfParticipants")?.toInt() ?: 0
+
 
                     if (otherUserId == null) {
                         remaining -= 1
@@ -293,7 +288,8 @@ class MessagesViewModel : ViewModel() {
                             previewSlots[index] = ConversationPreview(
                                 otherUserId = otherUserId,
                                 otherUserName = otherUserName,
-                                lastMessage = lastMessage
+                                lastMessage = lastMessage,
+                                numOfParticipants = numOfParticipants
                             )
 
                             remaining -= 1
@@ -305,7 +301,8 @@ class MessagesViewModel : ViewModel() {
                             previewSlots[index] = ConversationPreview(
                                 otherUserId = otherUserId,
                                 otherUserName = "Unknown User",
-                                lastMessage = lastMessage
+                                lastMessage = lastMessage,
+                                numOfParticipants = numOfParticipants
                             )
 
                             remaining -= 1

--- a/app/src/main/java/com/example/ekhogo/message/unsendMessage.kt
+++ b/app/src/main/java/com/example/ekhogo/message/unsendMessage.kt
@@ -1,0 +1,2 @@
+package com.example.ekhogo.message
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ui = "1.10.6"
 foundationLayout = "1.10.6"
 places = "5.1.1"
 firebaseAppcheckDebug = "19.0.2"
+foundationVersion = "1.11.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -39,6 +40,7 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "ui" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
 places = { group = "com.google.android.libraries.places", name = "places", version.ref = "places" }
 firebase-appcheck-debug = { group = "com.google.firebase", name = "firebase-appcheck-debug", version.ref = "firebaseAppcheckDebug" }
+androidx-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundationVersion" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
User can now delete message threads by swiping left on the message. Temporary deletion (messages still exist in firebase) if only 1 user swipes and permament if both have message thread deleted.

Names displayed above messages when other user replies to easily understand who you're messaging.

Added unsend funcitonality where user can hold on sent messages and unsend for both sides but message stating a message was unsent is sent.

In chat screen auto scrolls down to recent messages when messages are larger than one screen.