### PR TITLE
Added class-based search for classmates

### DIFF
--- a/app/src/main/java/com/example/ekhogo/friends/Friend.kt
+++ b/app/src/main/java/com/example/ekhogo/friends/Friend.kt
@@ -13,5 +13,6 @@ data class Friend(
     val major: String,
     val bio: String = "",
     val profileImageUrl: String = "",
+    val classesList: List<String> = emptyList(),
     val status: FriendStatus = FriendStatus.NONE
 )

--- a/app/src/main/java/com/example/ekhogo/friends/FriendsRepository.kt
+++ b/app/src/main/java/com/example/ekhogo/friends/FriendsRepository.kt
@@ -98,6 +98,9 @@ class FriendsRepository {
                                                 val major = document.getString("major") ?: ""
                                                 val bio = document.getString("bio") ?: ""
                                                 val profileImageUrl = document.getString("profileImageUrl") ?: ""
+                                                val classesList = (document.get("classes") as? List<*>)
+                                                    ?.filterIsInstance<String>()
+                                                    ?: emptyList()
 
                                                 if (uid == currentUserId) {
                                                     return@mapNotNull null
@@ -116,6 +119,7 @@ class FriendsRepository {
                                                     major = major,
                                                     bio = bio,
                                                     profileImageUrl = profileImageUrl,
+                                                    classesList = classesList,
                                                     status = status
                                                 )
                                             }.sortedBy { it.name.lowercase() }

--- a/app/src/main/java/com/example/ekhogo/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/example/ekhogo/friends/FriendsScreen.kt
@@ -104,7 +104,10 @@ fun FriendsScreen(
     val displayedClassmates =
         if (selectedTab == FriendsTab.ADD_FRIENDS) {
             visibleClassmates.filter { currentFriend ->
-                currentFriend.name.contains(searchText, ignoreCase = true)
+                currentFriend.name.contains(searchText, ignoreCase = true) ||
+                        currentFriend.classesList.any { className ->
+                            className.contains(searchText, ignoreCase = true)
+                        }
             }
         } else {
             visibleClassmates
@@ -177,7 +180,7 @@ fun FriendsScreen(
             OutlinedTextField(
                 value = searchText,
                 onValueChange = { searchText = it },
-                label = { Text("Search classmates") },
+                label = { Text("Search classmates by name or class") },
                 modifier = Modifier.fillMaxWidth()
             )
         }


### PR DESCRIPTION
Added class-based search for classmates
-In the friends screen add friend tab you can now use the search bar to find other users to add based on class.
-Class isn't case sensitive (Ex. COMP 350 or comp 350)
-Takes class data from Firestore arrays
-Improves finding users to add that are enrolled in the same class as you