### PR TITLE
fixed minor issue

### DIFF
--- a/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
+++ b/app/src/main/java/com/example/ekhogo/message/MessagesScreen.kt
@@ -179,7 +179,7 @@ fun MessagesScreen(viewModel: MessagesViewModel) {
                                     confirmValueChange = { value ->
                                         if (value == SwipeToDismissBoxValue.EndToStart) {
                                             deleteMessageThread(preview.conversationId)
-                                            true
+                                            false
                                         } else {
                                             false
                                         }


### PR DESCRIPTION
Message swiping box would stay in swiped position if user swiped to delete message thread and received message without switching to another screen. Updated swipe logic to fix error.